### PR TITLE
use libpng-dev instead of libpng12-dev, removed checksum-check before composer installation

### DIFF
--- a/config/php-fpm/Dockerfile
+++ b/config/php-fpm/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
-    libpng12-dev
+    libpng-dev
 
 # Install PHP extensions
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
@@ -42,7 +42,6 @@ RUN ln -snf /usr/share/zoneinfo/${PHP_TIMEZONE} /etc/localtime && echo ${PHP_TIM
 
 # Install composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 RUN php composer-setup.php
 RUN php -r "unlink('composer-setup.php');"
 RUN mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
use libpng-dev instead of libpng12-dev to prevent error "E: Package 'libpng12-dev' has no installation candidate"

removed checksum-check before compose installation to prevent errors during build when the composer installation file changes