### PR TITLE
Added missing "listen to port 80" in nginx config

### DIFF
--- a/config/nginx/project.conf
+++ b/config/nginx/project.conf
@@ -1,4 +1,7 @@
 server {
+    listen 80;
+    listen [::]:80;
+
     server_name __PROJECT_DOMAIN__;
     root /var/www/project/web;
 


### PR DESCRIPTION
After playing around with the setup on my linux machine, I discovered that `sulu.localhost:10080` don't show up the frontend of the sulu installation, instead the welcome screen of nginx.