### PR TITLE
Install inkscape for better svg handling with imagemagick

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y \
     openssl \
     git \
     unzip \
-    libmagickwand-dev
+    libmagickwand-dev \
+    inkscape
 
 # Install PHP extensions
 RUN docker-php-ext-install -j$(nproc) \


### PR DESCRIPTION
The internal SVG renderer of ImageMagick is quite buggy. Fortunately, ImageMagick will automatically use inkscape if it is present in the path. See: http://www.imagemagick.org/script/formats.php